### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ aiohttp_utils
     :target: https://travis-ci.org/sloria/aiohttp_utils
     :alt: Travis-CI
 
-**aiohttp_utils** provides handy utilities for building `aiohttp.web <http://aiohttp.readthedocs.org/>`_ applications.
+**aiohttp_utils** provides handy utilities for building `aiohttp.web <https://aiohttp.readthedocs.io/>`_ applications.
 
 
 * Method-based handlers ("resources")
@@ -64,13 +64,13 @@ Install
 Documentation
 =============
 
-Full documentation is available at https://aiohttp-utils.readthedocs.org/.
+Full documentation is available at https://aiohttp-utils.readthedocs.io/.
 
 Project Links
 =============
 
-- Docs: http://aiohttp-utils.readthedocs.org/
-- Changelog: http://aiohttp-utils.readthedocs.org/en/latest/changelog.html
+- Docs: https://aiohttp-utils.readthedocs.io/
+- Changelog: https://aiohttp-utils.readthedocs.io/en/latest/changelog.html
 - PyPI: https://pypi.python.org/pypi/aiohttp_utils
 - Issues: https://github.com/sloria/aiohttp_utils/issues
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,8 +20,8 @@ primary_domain = 'py'
 default_role = 'py:obj'
 
 intersphinx_mapping = {
-    'python': ('http://python.readthedocs.org/en/latest/', None),
-    'aiohttp': ('http://aiohttp.readthedocs.org/en/stable/', None),
+    'python': ('https://python.readthedocs.io/en/latest/', None),
+    'aiohttp': ('https://aiohttp.readthedocs.io/en/stable/', None),
 }
 
 issues_github_path = 'sloria/aiohttp_utils'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,7 +3,7 @@ aiohttp_utils
 
 Release v\ |version|. (:ref:`Changelog <changelog>`)
 
-**aiohttp_utils** provides handy utilities for building `aiohttp.web <http://aiohttp.readthedocs.org/>`_ applications.
+**aiohttp_utils** provides handy utilities for building `aiohttp.web <https://aiohttp.readthedocs.io/>`_ applications.
 
 
 * Method-based handlers ("resources")


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.